### PR TITLE
Update hyper_transforms.R to remove deprecated CFtime function

### DIFF
--- a/R/hyper_transforms.R
+++ b/R/hyper_transforms.R
@@ -72,7 +72,7 @@ hyper_transforms.default <- function(x, all = FALSE, ...) {
     ## instance from the extended attributes
     ## tidync/issues/54
     if (!is.na(dims$time[i]))
-      axis$timestamp <- CFtime::CFtimestamp(dims$time[i][[1]])
+      axis$timestamp <- CFtime::as_timestamp(dims$time[i][[1]])
     
     ## axis might have a column called "i"  
     ## tidync/issues/74


### PR DESCRIPTION
## Description
Package `CFtime` has had function `CFtimestamp()` deprecated over a year ago. This deprecated function will be removed imminently. The call to the deprecated function has been updated to a call to `CFtime::as_timestamp()` with identical functionality.